### PR TITLE
Add boot scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.terraform
+.terraform.lock.hcl
+

--- a/dropins/tests/README.md
+++ b/dropins/tests/README.md
@@ -1,0 +1,1 @@
+This is purely for files we want to use as part of our test suite. Due to the construction of the module and how terraform works, they have to live here. Terraform considers the top level directory to be both path.module and path.root when running tests.

--- a/dropins/tests/sidekiq_per_core.sh.tftpl
+++ b/dropins/tests/sidekiq_per_core.sh.tftpl
@@ -1,0 +1,16 @@
+core_count=${coalesce(instance_count, "$(nproc --all)")}
+jobs_count=$((core_count - 1))
+DROP_IN="/etc/systemd/system/teak-configurator.service.d"
+mkdir -p $DROP_IN
+UPHOLDS_FILE="$${DROP_IN}/40_upholds.conf"
+printf "[Unit]\n" > $UPHOLDS_FILE
+
+for i in $(seq 0 $jobs_count)
+do
+  DROP_IN="/etc/systemd/system/teak-${service_name}-sidekiq@$${i}.service.d"
+  mkdir -p $DROP_IN
+  printf "[Service]\nAllowedCPUs=$${i}\n" > "$${DROP_IN}/40_cpu_lock.conf"
+  printf "Upholds=teak-${service_name}-sidekiq@$${i}.service\n" >> $UPHOLDS_FILE
+done
+
+systemctl daemon-reload

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,7 @@ output "target_group" {
 output "launch_template" {
   description = "The EC2 launch template created by this module."
   value       = aws_launch_template.template
+  sensitive   = true
 }
 
 output "iam_role" {

--- a/tests/dropins/sidekiq_per_core.sh.tftpl
+++ b/tests/dropins/sidekiq_per_core.sh.tftpl
@@ -1,0 +1,16 @@
+core_count=${coalesce(instance_count, "$(nproc --all)")}
+jobs_count=$((core_count - 1))
+DROP_IN="/etc/systemd/system/teak-configurator.service.d"
+mkdir -p $DROP_IN
+UPHOLDS_FILE="$${DROP_IN}/40_upholds.conf"
+printf "[Unit]\n" > $UPHOLDS_FILE
+
+for i in $(seq 0 $jobs_count)
+do
+  DROP_IN="/etc/systemd/system/teak-${service_name}-sidekiq@$${i}.service.d"
+  mkdir -p $DROP_IN
+  printf "[Service]\nAllowedCPUs=$${i}\n" > "$${DROP_IN}/40_cpu_lock.conf"
+  printf "Upholds=teak-${service_name}-sidekiq@$${i}.service\n" >> $UPHOLDS_FILE
+done
+
+systemctl daemon-reload

--- a/tests/expected_user_data/README.md
+++ b/tests/expected_user_data/README.md
@@ -1,0 +1,1 @@
+The yaml files in this directly MUST NOT have trailing whitespace stripped.

--- a/tests/expected_user_data/no_info.yml
+++ b/tests/expected_user_data/no_info.yml
@@ -1,0 +1,8 @@
+## template: jinja
+#cloud-config
+hostname: "{{ v1.availability_zone }}-{{ v1.local_hostname }}"
+write_files:
+  - path: /etc/teak-configurator/30_fallbacks.yml.conf
+    owner: root:root
+    content: |
+     fallback_s3_bucket: configbucket

--- a/tests/expected_user_data/sidekiq_per_core.yml
+++ b/tests/expected_user_data/sidekiq_per_core.yml
@@ -1,0 +1,27 @@
+## template: jinja
+#cloud-config
+hostname: "{{ v1.availability_zone }}-{{ v1.local_hostname }}"
+write_files:
+  - path: /etc/teak-configurator/30_fallbacks.yml.conf
+    owner: root:root
+    content: |
+     fallback_s3_bucket: configbucket
+     
+bootcmd:
+  - |
+   core_count=$(nproc --all)
+     jobs_count=$((core_count - 1))
+     DROP_IN="/etc/systemd/system/teak-configurator.service.d"
+     mkdir -p $DROP_IN
+     UPHOLDS_FILE="${DROP_IN}/40_upholds.conf"
+     printf "[Unit]\n" > $UPHOLDS_FILE
+     
+     for i in $(seq 0 $jobs_count)
+     do
+       DROP_IN="/etc/systemd/system/teak-test-sidekiq@${i}.service.d"
+       mkdir -p $DROP_IN
+       printf "[Service]\nAllowedCPUs=${i}\n" > "${DROP_IN}/40_cpu_lock.conf"
+       printf "Upholds=teak-test-sidekiq@${i}.service\n" >> $UPHOLDS_FILE
+     done
+     
+     systemctl daemon-reload

--- a/tests/user_data.tftest.hcl
+++ b/tests/user_data.tftest.hcl
@@ -1,0 +1,67 @@
+mock_provider "aws" {
+  override_data {
+    target = data.aws_ec2_instance_type.instance-info
+    values = {
+      "supported_architectures" = ["arm64"]
+    }
+  }
+
+  override_data {
+    target = data.aws_iam_policy_document.allow_ec2_assume
+    values = {
+      "json" = "{}"
+    }
+  }
+
+}
+mock_provider "aws" {
+  alias = "meta"
+
+  override_data {
+    target = data.aws_ssm_parameter.account-info
+    values = {
+      value = "{\"prefix\":\"/test\"}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ssm_parameters_by_path.core-config
+    values = {
+      names = ["/test/config/core/config_backup_bucket", "/test/config/core/public_service_subnet_ids"]
+      values = ["configbucket", "subnet-1234"]
+    }
+  }
+}
+
+variables {
+  service_name = "test"
+  network_level = "public"
+  instance_type = "t4g.micro"
+  volume_size = 2
+  min_instances = 0
+  max_instances = 0
+}
+
+run "no_info" {
+  command = plan
+
+  assert {
+    condition = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/no_info.yml"))
+    error_message = "Expected\n${trimspace(file("${path.module}/tests/expected_user_data/no_info.yml"))}\ngot\n${trimspace(base64decode(aws_launch_template.template.user_data))}\n"
+  }
+}
+
+run "boot_scripts" {
+  command = plan
+
+  variables {
+    boot_scripts = {
+      "tests/sidekiq_per_core.sh.tftpl" = { instance_count = null, service_name = "test" }
+    }
+  }
+
+  assert {
+    condition = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/sidekiq_per_core.yml"))
+    error_message = "Expected\n${trimspace(file("${path.module}/tests/expected_user_data/sidekiq_per_core.yml"))}\ngot\n${trimspace(base64decode(aws_launch_template.template.user_data))}\n"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,16 @@ variable "enabled_services" {
 EOM
 }
 
+variable "boot_scripts" {
+  type        = map(map(any))
+  default     = {}
+  description = <<-EOM
+  A list of files to be run as additional scripts at instance boot time. The keys in the map serve as the source path.
+  The file will be read from $${path.root}/dropins/$${key} and placed into the list of cloud-init bootcmds, prior to any enabled_services.
+  The values are maps which will be templated into the file read locally using Terraform's templatefile function.
+EOM
+}
+
 variable "subnet_ids" {
   type        = list(string)
   description = "A list of subnet ids that service servers may run in. Must all be in the same VPC."


### PR DESCRIPTION
This gives us a way to drop in boot scripts the same way we drop in other files, so that can be done without needing to fully customize user_data.