### PR TITLE
Allow aws provider 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.6
+
+ENHANCEMENTS:
+
+* Allow aws provider 6.x
+
 ## 0.5.5
 
 BREAKING CHANGES:

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.22, < 6"
+      version = ">= 4.22, < 7"
 
       configuration_aliases = [aws.meta]
     }

--- a/tests/user_data.tftest.hcl
+++ b/tests/user_data.tftest.hcl
@@ -13,6 +13,13 @@ mock_provider "aws" {
     }
   }
 
+  override_data {
+    target = data.aws_iam_policy.default-policies
+    values = {
+      "arn" = "arn:aws:iam::aws:policy/mock"
+    }
+  }
+
 }
 mock_provider "aws" {
   alias = "meta"
@@ -27,17 +34,17 @@ mock_provider "aws" {
   override_data {
     target = data.aws_ssm_parameters_by_path.core-config
     values = {
-      names = ["/test/config/core/config_backup_bucket", "/test/config/core/public_service_subnet_ids"]
+      names  = ["/test/config/core/config_backup_bucket", "/test/config/core/public_service_subnet_ids"]
       values = ["configbucket", "subnet-1234"]
     }
   }
 }
 
 variables {
-  service_name = "test"
+  service_name  = "test"
   network_level = "public"
   instance_type = "t4g.micro"
-  volume_size = 2
+  volume_size   = 2
   min_instances = 0
   max_instances = 0
 }
@@ -46,7 +53,7 @@ run "no_info" {
   command = plan
 
   assert {
-    condition = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/no_info.yml"))
+    condition     = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/no_info.yml"))
     error_message = "Expected\n${trimspace(file("${path.module}/tests/expected_user_data/no_info.yml"))}\ngot\n${trimspace(base64decode(aws_launch_template.template.user_data))}\n"
   }
 }
@@ -61,7 +68,7 @@ run "boot_scripts" {
   }
 
   assert {
-    condition = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/sidekiq_per_core.yml"))
+    condition     = trimspace(base64decode(aws_launch_template.template.user_data)) == trimspace(file("${path.module}/tests/expected_user_data/sidekiq_per_core.yml"))
     error_message = "Expected\n${trimspace(file("${path.module}/tests/expected_user_data/sidekiq_per_core.yml"))}\ngot\n${trimspace(base64decode(aws_launch_template.template.user_data))}\n"
   }
 }


### PR DESCRIPTION
Widens the required_providers constraint from `< 6` to `< 7` so consumers can move to the AWS provider's 6.x series. Constraint edit only — no resource changes; the audit is downstream, in taro's `terraform plan` (see https://linear.app/teakio/issue/C-1353/upgrade-taros-aws-provider-from-5x-to-6x).

v6 tightens ARN-format validation on `aws_iam_role_policy_attachment.policy_arn`. Production is unaffected — that attribute is always fed a real ARN from the `aws_iam_policy` data source — but the test's mocked data source now needs a well-formed placeholder ARN to satisfy the stricter validation; updated the mock accordingly.

`terraform init -upgrade && terraform test` passes against aws 6.57.1.

[teak-taro-worker-c-1353] Part of Linear C-1353 (upgrade taro's AWS provider from 5.x to 6.x).